### PR TITLE
tidy up function call example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ class GameEngine {
 "##).unwrap();
 let handle = vm.make_call_handle(FunctionSignature::new_function("update", 1));
 vm.execute(|vm| {
+    vm.ensure_slots(2);
     vm.get_variable("main", "GameEngine", 0);
-    vm.set_slot_double(0, 0.016);
+    vm.set_slot_double(1, 0.016);
 });
 vm.call_handle(&handle);
 ```
@@ -64,8 +65,9 @@ class GameEngine {
 }
 "##).unwrap();
 vm.execute(|vm| {
+    vm.ensure_slots(2);
     vm.get_variable("main", "GameEngine", 0);
-    vm.set_slot_double(0, 0.016);
+    vm.set_slot_double(1, 0.016);
 });
 vm.call(FunctionSignature::new_function("update", 1));
 ```


### PR DESCRIPTION
my program was crashing with a `STATUS_ACCESS_VIOLATION` error when i tried to call a function defined in Wren the way the README currently says to do that, and adding the `ensure_slots` call to my code fixed that. i also was getting an error because it was trying to use the argument as the receiver of the method call and not the class, so i've applied here the same fix that worked for me.