### PR TITLE
Memory leak when clearing empty list

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,8 +8,12 @@ use crate::{UserData, WrenError};
 pub extern "C" fn wren_realloc(memory: *mut ffi::c_void, new_size: wren_sys::size_t) -> *mut ffi::c_void {
     unsafe {
         if memory.is_null() { // If memory == NULL
-            // allocate new memory
-            std::alloc::alloc_zeroed(std::alloc::Layout::from_size_align(new_size as usize, 8).unwrap()) as *mut _
+            if new_size == 0 {
+                std::ptr::null_mut()
+            } else {
+                // allocate new memory
+                std::alloc::alloc_zeroed(std::alloc::Layout::from_size_align(new_size as usize, 8).unwrap()) as *mut _
+            }
         } else {
             // Memory is an actual pointer to a location.
             if new_size == 0 {


### PR DESCRIPTION
I've identified a memory leak in the allocation logic.

When clearing an empty list reallocation calls `std::alloc::alloc_zeroed()` with a null pointer and a `new_size` of 0. On my system this still allocates memory. Wren does not handle the returned pointer.

This can be recreated by interpreting the following script:

```wren
var x = []

while (true) {
    x.clear()
}
```

In Wren the culprit is the value buffer backing the list. The code can be found in the buffer macro: https://github.com/wren-lang/wren/blob/9dfbc021a03d6313c48d8975f5168db740ce7e0d/src/vm/wren_utils.h#L40

When the value buffer is empty, the argument `buffer->data` passed to `wrenReallocate()`  is `NULL`.
