### PR TITLE
feat: add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ ruwren-sys = { version = "0.5.0", path = "ruwren-sys" }
 ruwren-macros = { version = "0.5.0", path = "ruwren-macros", optional = true }
 
 [features]
-default = ["derive"]
+default = ["derive", "std"]
 derive = ["dep:ruwren-macros"]
+std = []
 
 [dev-dependencies]
 criterion = "0.7"

--- a/examples/v2_integration_manual.rs
+++ b/examples/v2_integration_manual.rs
@@ -197,7 +197,7 @@ impl FooClass {
     }
 }
 
-impl<'a> FooWrapper<'a> {
+impl FooWrapper<'_> {
     fn bar(&mut self, val: Option<f64>) {
         match val {
             Some(val) => {

--- a/ruwren-macros/src/lib.rs
+++ b/ruwren-macros/src/lib.rs
@@ -48,7 +48,7 @@ fn generate_class(
             quote! {
                 struct #cname;
 
-                impl From<#name> for #cname {
+                impl ::core::convert::From<#name> for #cname {
                     #[inline]
                     fn from(source: #name) -> Self {
                         Self
@@ -88,7 +88,7 @@ fn generate_class(
                     ),*
                 }
 
-                impl From<#name> for #cname {
+                impl ::core::convert::From<#name> for #cname {
                     #[inline]
                     fn from(source: #name) -> Self {
                         Self {
@@ -138,7 +138,7 @@ fn generate_class(
                         ),*
                     );
 
-                    impl From<#name> for #cname {
+                    impl ::core::convert::From<#name> for #cname {
                         #[inline]
                         fn from(source: #name) -> Self {
                             Self (
@@ -153,7 +153,7 @@ fn generate_class(
                 quote! {
                     struct #cname;
 
-                    impl From<#name> for #cname {
+                    impl ::core::convert::From<#name> for #cname {
                         #[inline]
                         fn from(source: #name) -> Self {
                             Self
@@ -174,7 +174,7 @@ fn generate_instance(
             quote! {
                 struct #iname;
 
-                impl From<#name> for #iname {
+                impl ::core::convert::From<#name> for #iname {
                     #[inline]
                     fn from(source: #name) -> Self {
                         Self
@@ -214,7 +214,7 @@ fn generate_instance(
                     ),*
                 }
 
-                impl From<#name> for #iname {
+                impl ::core::convert::From<#name> for #iname {
                     #[inline]
                     fn from(source: #name) -> Self {
                         Self {
@@ -264,7 +264,7 @@ fn generate_instance(
                         ),*
                     );
 
-                    impl From<#name> for #iname {
+                    impl ::core::convert::From<#name> for #iname {
                         #[inline]
                         fn from(source: #name) -> Self {
                             Self (
@@ -279,7 +279,7 @@ fn generate_instance(
                 quote! {
                     struct #iname;
 
-                    impl From<#name> for #iname {
+                    impl ::core::convert::From<#name> for #iname {
                         #[inline]
                         fn from(source: #name) -> Self {
                             Self
@@ -302,21 +302,21 @@ fn generate_wrapper(name: &syn::Ident) -> proc_macro2::TokenStream {
             instance: &'a mut #iname,
         }
 
-        impl<'a> From<&#wname<'a>> for #name {
+        impl<'a> ::core::convert::From<&#wname<'a>> for #name {
             #[inline]
             fn from(wrapper: &#wname<'a>) -> Self {
                 (&*wrapper.class, &*wrapper.instance).into()
             }
         }
 
-        impl<'a> From<(&'a mut #cname, &'a mut #iname)> for #wname<'a> {
+        impl<'a> ::core::convert::From<(&'a mut #cname, &'a mut #iname)> for #wname<'a> {
             #[inline]
             fn from((class, instance): (&'a mut #cname, &'a mut #iname)) -> Self {
                 Self { class, instance }
             }
         }
 
-        impl<'a> std::ops::Deref for #wname<'a> {
+        impl<'a> ::core::ops::Deref for #wname<'a> {
             type Target = #iname;
             #[inline]
             fn deref(&self) -> &#iname {
@@ -324,7 +324,7 @@ fn generate_wrapper(name: &syn::Ident) -> proc_macro2::TokenStream {
             }
         }
 
-        impl<'a> std::ops::DerefMut for #wname<'a> {
+        impl<'a> ::core::ops::DerefMut for #wname<'a> {
             #[inline]
             fn deref_mut(&mut self) -> &mut #iname {
                 &mut self.instance
@@ -407,7 +407,7 @@ fn generate_enhancements(
     };
 
     quote! {
-        impl<'a> From<(&'a #class_name, &'a #instance_name)> for #name {
+        impl<'a> ::core::convert::From<(&'a #class_name, &'a #instance_name)> for #name {
             #[allow(clippy::clone_on_copy)]
             #[inline]
             fn from((class, inst): (&'a #class_name, &'a #instance_name)) -> Self {
@@ -415,10 +415,10 @@ fn generate_enhancements(
             }
         }
 
-        impl TryFrom<Option<#name>> for #name {
+        impl ::core::convert::TryFrom<::core::option::Option<#name>> for #name {
             type Error = ();
 
-            fn try_from(value: Option<#name>) -> Result<Self, Self::Error> {
+            fn try_from(value: Option<#name>) -> ::core::result::Result<Self, Self::Error> {
                 value.ok_or(())
             }
         }
@@ -581,11 +581,11 @@ impl WrenImplValidFn {
                 };
                 let failure = if constructor_mode {
                     quote! {
-                        return Err(format!("failed to get value of type {} for slot {}", std::any::type_name::<#ty>(), #slot_idx));
+                        return Err(format!("failed to get value of type {} for slot {}", core::any::type_name::<#ty>(), #slot_idx));
                     }
                 } else {
                     quote! {
-                        ruwren::foreign_v2::WrenTo::to_vm(format!("failed to get value of type {} for slot {}", std::any::type_name::<#ty>(), #slot_idx), vm, 0, 1);
+                        ruwren::foreign_v2::WrenTo::to_vm(format!("failed to get value of type {} for slot {}", core::any::type_name::<#ty>(), #slot_idx), vm, 0, 1);
                         vm.abort_fiber(0);
                         return
                     }
@@ -642,11 +642,11 @@ impl WrenImplValidFn {
             };
             let failure = if constructor_mode {
                 quote! {
-                    return Err(format!("failed to get value of type {} for slot {}", std::any::type_name::<#ty>(), #slot_idx));
+                    return Err(format!("failed to get value of type {} for slot {}", core::any::type_name::<#ty>(), #slot_idx));
                 }
             } else {
                 quote! {
-                    ruwren::foreign_v2::WrenTo::to_vm(format!("failed to get value of type {} for slot {}", std::any::type_name::<#ty>(), #slot_idx), vm, 0, 1);
+                    ruwren::foreign_v2::WrenTo::to_vm(format!("failed to get value of type {} for slot {}", core::any::type_name::<#ty>(), #slot_idx), vm, 0, 1);
                     vm.abort_fiber(0);
                     return
                 }
@@ -683,7 +683,7 @@ impl WrenImplValidFn {
                             Err(_) => panic!(
                                 "slot {} cannot be type {}",
                                 #slot_idx,
-                                std::any::type_name::<#ty>()
+                                core::any::type_name::<#ty>()
                             ),
                         }
                     }
@@ -784,7 +784,7 @@ impl WrenImplValidFn {
                 #vis unsafe extern "C" fn #native_name(vm: *mut ruwren::wren_sys::WrenVM) {
                     use std::panic::{set_hook, take_hook, AssertUnwindSafe};
 
-                    let conf = std::ptr::read_unaligned(
+                    let conf = ::core::ptr::read_unaligned(
                         ruwren::wren_sys::wrenGetUserData(vm) as *mut ruwren::UserData
                     );
                     let ovm = vm;
@@ -801,7 +801,7 @@ impl WrenImplValidFn {
                         })
                     };
                     drop(take_hook());
-                    std::ptr::write_unaligned(
+                    ::core::ptr::write_unaligned(
                         ruwren::wren_sys::wrenGetUserData(ovm) as *mut ruwren::UserData,
                         conf,
                     );
@@ -812,7 +812,7 @@ impl WrenImplValidFn {
                 #vis unsafe extern "C" fn #native_name(vm: *mut ruwren::wren_sys::WrenVM) {
                     use std::panic::{set_hook, take_hook, AssertUnwindSafe};
 
-                    let conf = std::ptr::read_unaligned(
+                    let conf = ::core::ptr::read_unaligned(
                         ruwren::wren_sys::wrenGetUserData(vm) as *mut ruwren::UserData
                     );
                     let ovm = vm;
@@ -828,7 +828,7 @@ impl WrenImplValidFn {
                             .unwrap_or_else(|| panic!(
                                 "Tried to call {0} of {1} on non-{1} type",
                                 stringify!($inf),
-                                std::any::type_name::<#instance_name>()
+                                ::core::any::type_name::<#instance_name>()
                             ));
                         vm_borrow.use_class_mut::<#instance_name, _, _>(|vm, cls| {
                             let class =
@@ -838,7 +838,7 @@ impl WrenImplValidFn {
                         })
                     };
                     drop(take_hook());
-                    std::ptr::write_unaligned(
+                    ::core::ptr::write_unaligned(
                         ruwren::wren_sys::wrenGetUserData(ovm) as *mut ruwren::UserData,
                         conf,
                     );
@@ -1405,7 +1405,7 @@ pub fn wren_impl(
                     use ruwren::handle_panic as catch_unwind;
                     unsafe {
                         let ud = ruwren::wren_sys::wrenGetUserData(vm);
-                        let conf = std::ptr::read_unaligned(ud as *mut ruwren::UserData);
+                        let conf = core::ptr::read_unaligned(ud as *mut ruwren::UserData);
                         let ovm = vm;
                         let vm = std::rc::Weak::upgrade(&conf.vm)
                             .unwrap_or_else(|| panic!("Failed to access VM at {:p}", &conf.vm));
@@ -1422,11 +1422,11 @@ pub fn wren_impl(
                                     std::mem::size_of::<ruwren::ForeignObject<#instance_ty>>()
                                 );
 
-                                std::ptr::write(
+                                core::ptr::write(
                                     wptr as *mut _,
                                     ruwren::ForeignObject {
                                         object: Box::into_raw(Box::new(object)),
-                                        type_id: std::any::TypeId::of::<#instance_ty>(),
+                                        type_id: core::any::TypeId::of::<#instance_ty>(),
                                     },
                                 );
                             },
@@ -1436,7 +1436,7 @@ pub fn wren_impl(
                             }
                         };
                         drop(take_hook());
-                        std::ptr::write_unaligned(
+                        core::ptr::write_unaligned(
                             ud as *mut ruwren::UserData,
                             conf
                         );
@@ -1453,12 +1453,12 @@ pub fn wren_impl(
                 extern "C" fn _destructor(data: *mut std::ffi::c_void) {
                     unsafe {
                         let mut fo: ruwren::ForeignObject<#instance_ty> =
-                            std::ptr::read_unaligned(data as *mut _);
+                            ::core::ptr::read_unaligned(data as *mut _);
                         if !fo.object.is_null() {
                             _ = Box::from_raw(fo.object);
                         }
-                        fo.object = std::ptr::null_mut();
-                        std::ptr::write_unaligned(data as *mut _, fo);
+                        fo.object = core::ptr::null_mut();
+                        ::core::ptr::write_unaligned(data as *mut _, fo);
                     }
                 }
 

--- a/ruwren-sys/build.rs
+++ b/ruwren-sys/build.rs
@@ -33,6 +33,7 @@ fn main() {
     let bindings = bindgen::Builder::default()
         .detect_include_paths(true)
         .header("wrapper.h")
+        .use_core()
         .allowlist_var("WREN.*")
         .allowlist_type("Wren.*")
         .allowlist_function("wren.*")

--- a/ruwren-sys/lib.rs
+++ b/ruwren-sys/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/ruwren_web_example/src/main.rs
+++ b/ruwren_web_example/src/main.rs
@@ -1,4 +1,5 @@
 use ruwren::{wren_impl, wren_module, ModuleLibrary, VMConfig, WrenObject};
+
 #[derive(WrenObject, Default)]
 struct Foo {
     bar: f64,

--- a/src/foreign_v2.rs
+++ b/src/foreign_v2.rs
@@ -1,9 +1,9 @@
 mod convert;
 
-use std::{
+use alloc::{boxed::Box, rc::Rc, string::String, vec, vec::Vec};
+use core::{
     any::{Any, TypeId},
     cell::RefCell,
-    rc::Rc,
 };
 
 pub use convert::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ where
     std::panic::catch_unwind(func)
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "std"))]
 pub fn handle_panic<F, O: 'static>(func: F) -> Result<O, Box<dyn Any + Send>>
 where
     F: FnOnce() -> O + core::panic::UnwindSafe,
@@ -89,6 +89,16 @@ where
         Ok(o) => Ok(o),
         _ => unreachable!("non-unwinding platforms (like WASM) can't catch unwinds, so don't panic unless absolutely necessary"),
     }
+}
+
+#[cfg(not(feature = "std"))]
+pub fn handle_panic<F, O: 'static>(func: F) -> Result<O, Box<dyn Any + Send>>
+where
+    F: FnOnce() -> O + core::panic::UnwindSafe,
+{
+    // `no_std` cannot currently catch unwind.
+    // See <https://github.com/rust-lang/rfcs/issues/2810>
+    Ok(func())
 }
 
 impl core::fmt::Display for VMError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub enum WrenError {
     StackTrace(String, i32, String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 /// Possible errors for a Wren script
 pub enum VMError {
     Compile {
@@ -65,7 +65,7 @@ pub enum VMError {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VMStackFrameError {
     pub module: String,
     pub line: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ use core::{
     cell::RefCell,
     ffi, marker, mem,
 };
-use std::sync::mpsc::{channel, Receiver, Sender};
 
 use foreign_v2::ForeignItem;
 use wren_sys::{wrenGetUserData, WrenConfiguration, WrenHandle, WrenVM};
@@ -34,6 +33,7 @@ mod module_loader;
 #[cfg(feature = "std")]
 pub use module_loader::BasicFileLoader;
 
+#[cfg(feature = "std")]
 pub mod foreign_v1;
 pub mod foreign_v2;
 
@@ -72,12 +72,11 @@ pub struct VMStackFrameError {
     pub function: String,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
 pub fn handle_panic<F, O>(func: F) -> Result<O, Box<dyn Any + Send>>
 where
     F: FnOnce() -> O + core::panic::UnwindSafe,
 {
-    #[cfg(feature = "std")]
     std::panic::catch_unwind(func)
 }
 
@@ -310,6 +309,8 @@ impl Printer for PrintlnPrinter {
     fn print(&mut self, s: String) {
         #[cfg(feature = "std")]
         std::print!("{}", s);
+        // Avoid clippy error when `std` is disabled.
+        let _ = s;
     }
 }
 
@@ -319,12 +320,14 @@ type ClassMap = RefCell<BTreeMap<TypeId, Rc<RefCell<Box<dyn Any>>>>>;
 pub struct VM {
     pub vm: *mut WrenVM,
     classes_v2: ClassMap,
-    error_recv: Receiver<WrenError>,
+    /// Same as [`UserData::errors`]
+    errors: Rc<RefCell<Vec<WrenError>>>,
 }
 
 /// A mostly internal class that is exposed so that some externally generated code can access it.
 pub struct UserData {
-    error_channel: Sender<WrenError>,
+    /// Same as [`VM::errors`]
+    errors: Rc<RefCell<Vec<WrenError>>>,
     printer: Box<dyn Printer>,
     pub vm: Weak<RefCell<VM>>, // is used a *lot* by externally generated code.
     library: Option<ModuleLibrary>,
@@ -412,7 +415,9 @@ impl VMWrapper {
             wren_sys::WrenInterpretResult_WREN_RESULT_RUNTIME_ERROR => {
                 let mut error = "".to_string();
                 let mut frames = vec![];
-                while let Ok(err) = vm.error_recv.try_recv() {
+                let mut errors = vm.errors.borrow_mut();
+                let all_indices = 0..errors.len();
+                for err in errors.drain(all_indices) {
                     match err {
                         WrenError::Runtime(msg) => {
                             error = msg;
@@ -443,8 +448,11 @@ impl VMWrapper {
         match unsafe { wren_sys::wrenInterpret(vm.vm, module.as_ptr(), code.as_ptr()) } {
             wren_sys::WrenInterpretResult_WREN_RESULT_SUCCESS => Ok(()),
             wren_sys::WrenInterpretResult_WREN_RESULT_COMPILE_ERROR => {
-                match vm.error_recv.try_recv() {
-                    Ok(WrenError::Compile(module, line, msg)) => Err(VMError::Compile {
+                let mut errors = vm.errors.borrow_mut();
+                let all_indices = 0..errors.len();
+                let mut draiend_errors = errors.drain(all_indices);
+                match (draiend_errors.next(), draiend_errors.next()) {
+                    (Some(WrenError::Compile(module, line, msg)), None) => Err(VMError::Compile {
                         module,
                         line,
                         error: msg,
@@ -455,7 +463,9 @@ impl VMWrapper {
             wren_sys::WrenInterpretResult_WREN_RESULT_RUNTIME_ERROR => {
                 let mut error = "".to_string();
                 let mut frames = vec![];
-                while let Ok(err) = vm.error_recv.try_recv() {
+                let mut errors = vm.errors.borrow_mut();
+                let all_indices = 0..errors.len();
+                for err in errors.drain(all_indices) {
                     match err {
                         WrenError::Runtime(msg) => {
                             error = msg;
@@ -584,21 +594,20 @@ impl VMConfig {
     }
 
     pub fn build(self) -> VMWrapper {
-        let (etx, erx) = channel();
-
+        let errors = Rc::new(RefCell::new(Vec::new()));
         // Have an uninitialized VM...
         let wvm = Rc::new(RefCell::new(VM {
             vm: core::ptr::null_mut(),
             classes_v2: RefCell::new(BTreeMap::new()),
-            error_recv: erx,
+            errors: errors.clone(),
         }));
 
         let vm_config = Box::into_raw(Box::new(UserData {
-            error_channel: etx,
             printer: self.printer,
             vm: Rc::downgrade(&wvm),
             loader: self.script_loader,
             library: self.library,
+            errors,
         }));
 
         // Configure the Wren side of things

--- a/src/module_loader.rs
+++ b/src/module_loader.rs
@@ -1,12 +1,7 @@
-use crate::ModuleScriptLoader;
+use alloc::string::String;
 use std::path::{Path, PathBuf};
 
-pub struct NullLoader;
-impl ModuleScriptLoader for NullLoader {
-    fn load_script(&mut self, _: String) -> Option<String> {
-        None
-    }
-}
+use crate::ModuleScriptLoader;
 
 #[derive(Debug, Clone)]
 pub struct BasicFileLoader {
@@ -42,13 +37,13 @@ impl ModuleScriptLoader for BasicFileLoader {
                 match file.read_to_string(&mut contents) {
                     Ok(_) => Some(contents),
                     Err(file) => {
-                        eprintln!("failed to read file {:?}", file);
+                        std::eprintln!("failed to read file {:?}", file);
                         None
                     }
                 }
             }
             Err(file) => {
-                eprintln!("failed to open file {:?}", file);
+                std::eprintln!("failed to open file {:?}", file);
                 None
             }
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -49,32 +49,26 @@ pub extern "C" fn wren_error(
         wren_sys::WrenErrorType_WREN_ERROR_COMPILE => {
             let module_str = unsafe { ffi::CStr::from_ptr(module) };
             let message_str = unsafe { ffi::CStr::from_ptr(message) };
-            conf.error_channel
-                .send(WrenError::Compile(
-                    module_str.to_string_lossy().to_string(),
-                    line,
-                    message_str.to_string_lossy().to_string(),
-                ))
-                .unwrap();
+            conf.errors.borrow_mut().push(WrenError::Compile(
+                module_str.to_string_lossy().to_string(),
+                line,
+                message_str.to_string_lossy().to_string(),
+            ));
         }
         wren_sys::WrenErrorType_WREN_ERROR_RUNTIME => {
             let message_str = unsafe { ffi::CStr::from_ptr(message) };
-            conf.error_channel
-                .send(WrenError::Runtime(
-                    message_str.to_string_lossy().to_string(),
-                ))
-                .unwrap();
+            conf.errors.borrow_mut().push(WrenError::Runtime(
+                message_str.to_string_lossy().to_string(),
+            ));
         }
         wren_sys::WrenErrorType_WREN_ERROR_STACK_TRACE => {
             let module_str = unsafe { ffi::CStr::from_ptr(module) };
             let message_str = unsafe { ffi::CStr::from_ptr(message) };
-            conf.error_channel
-                .send(WrenError::StackTrace(
-                    module_str.to_string_lossy().to_string(),
-                    line,
-                    message_str.to_string_lossy().to_string(),
-                ))
-                .unwrap();
+            conf.errors.borrow_mut().push(WrenError::StackTrace(
+                module_str.to_string_lossy().to_string(),
+                line,
+                message_str.to_string_lossy().to_string(),
+            ));
         }
         _ => unreachable!(),
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use super::{create_module, get_slot_checked, VMConfig};
 
 struct Point {
@@ -86,7 +88,8 @@ fn init_vm() {
 fn test_small_wren_program() {
     let vm = VMConfig::new().build();
     let interp = vm.interpret("main", "System.print(\"I am running in a VM!\")");
-    println!("{:?}", interp);
+    #[cfg(feature = "std")]
+    std::println!("{:?}", interp);
     assert!(interp.is_ok());
 }
 
@@ -160,7 +163,8 @@ fn test_external_module() {
     }
     ",
     );
-    println!("{:?}", source);
+    #[cfg(feature = "std")]
+    std::println!("{:?}", source);
     assert!(source.is_ok());
 
     vm.execute(|vm| {
@@ -171,7 +175,8 @@ fn test_external_module() {
     let _ = vm.get_slot_handle(0);
     let interp = vm.call(super::FunctionSignature::new_function("update", 1));
     if let Err(e) = interp.clone() {
-        eprintln!("{}", e);
+        #[cfg(feature = "std")]
+        std::eprintln!("{}", e);
     }
     assert!(interp.is_ok());
     vm.execute(|vm| {
@@ -267,7 +272,8 @@ fn foreign_instance() {
     }
     ",
     );
-    println!("{:?}", source);
+    #[cfg(feature = "std")]
+    std::println!("{:?}", source);
     assert!(source.is_ok());
 
     vm.execute(|vm| {
@@ -279,7 +285,8 @@ fn foreign_instance() {
     let interp = vm.call(super::FunctionSignature::new_function("update", 1));
     let _ = vm.get_slot_handle(0);
     if let Err(e) = interp.clone() {
-        eprintln!("{}", e);
+        #[cfg(feature = "std")]
+        std::eprintln!("{}", e);
     }
     assert!(interp.is_ok());
     vm.execute(|vm| {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,8 @@
+use std::vec::Vec;
+
 use alloc::string::String;
+
+use crate::{VMError, VMStackFrameError};
 
 use super::{create_module, get_slot_checked, VMConfig};
 
@@ -293,4 +297,27 @@ fn foreign_instance() {
         assert_eq!(vm.get_slot_type(0), super::SlotType::Num);
         assert_eq!(vm.get_slot_double(0), Some(21.45));
     });
+}
+
+#[test]
+fn test_errors() {
+    let vm = VMConfig::new().build();
+    let result = vm.interpret(
+        "main",
+        "
+    var aMap = {}
+    aMap.unknownFunction()
+    ",
+    );
+    assert_eq!(
+        result,
+        Err(VMError::Runtime {
+            error: "Map does not implement 'unknownFunction()'.".into(),
+            frames: Vec::from_iter([VMStackFrameError {
+                module: "main".into(),
+                line: 3,
+                function: "(script)".into()
+            }]),
+        })
+    );
 }


### PR DESCRIPTION
Implements #22 (Work in progress)

- [x] `no_std` `ruwren-sys`
  This was pretty easy to fix: just added `#![no_std]` in `lib.rs` and `use_core()` for bindgen.
- [x] `no_std` macros from `ruwren-macros`
- [x] `no_std` `ruwren`
  - [x] Use `core` and `alloc` where possible
  - [x] Use `alloc::collections::BTreeMap` instead of `std::collections::HashMap` (`HashMap` is not yet available in `alloc`)
  - [x] Add `std` feature (turned on by default) to gate standard output prints and file module loader
  - [x] ~~Find a replacement for `std::panic::{take_hook, set_hook}` in `foreign_v1`?~~
    Or simply require the `std` feature for `foreign_v1`?
  - [x] Repalce `std::sync::mpsc` with `Rc<RefCell<Vec<_>>>`

~~The main blocking point is `std::sync::mpsc`.~~

I took the opportunity of improving macros by using full qualified imports (`::core` instated of `core`).

Note: I didn't find any info about the MSRV used by the project. I compiled and tested with Rust 1.85.1 